### PR TITLE
Crash in VideoCapture

### DIFF
--- a/src/+cv/private/VideoCapture_.cpp
+++ b/src/+cv/private/VideoCapture_.cpp
@@ -109,7 +109,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     		plhs[0] = MxArray(frame);
     	}
     	else
-    		plhs[0] = MxArray(Mat(0,0,CV_8UC1,Scalar(0)));
+    		plhs[0] = MxArray(Mat(1,1,CV_8UC1,Scalar(0)));
     }
     else if (method == "read") {
     	if (nrhs!=2)
@@ -126,7 +126,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     		plhs[0] = MxArray(frame);
     	}
     	else
-    		plhs[0] = MxArray(Mat(0,0,CV_8UC1,Scalar(0)));
+    		plhs[0] = MxArray(Mat(1,1,CV_8UC1,Scalar(0)));
     }
     else if (method == "get") {
     	if (nrhs!=3)


### PR DESCRIPTION
Hey. Like your library very much. Finding it very useful.
Found one bug:
When trying to capture, and the source has no more frames, we get a crash because it tries to return a 0x0 mat..
