### PR TITLE
expose additional functions of VideoCapture/VideoWriter

### DIFF
--- a/+cv/VideoCapture.m
+++ b/+cv/VideoCapture.m
@@ -128,5 +128,78 @@ classdef VideoCapture < handle
             VideoCapture_(this.id, 'set', key, value);
         end
     end
-    
+
+    methods (Hidden = true)
+        function successFlag = open(this, filename)
+            %OPEN  Open video file or a capturing device for video capturing
+            %
+            % ## Output
+            % * __retval__ bool, true if successful
+            %
+            % The methods release() to close the already opened file or camera.
+            % Parameters are the same as in the constructor.
+            %
+            % See also cv.VideoCapture.isOpened
+            %
+            if nargin < 1, filename = 0; end
+            successFlag = VideoCapture_(this.id, 'open', filename);
+        end
+
+        function flag = isOpened(this)
+            %ISOPENED  Returns true if video capturing has been initialized already.
+            %
+            % ## Output
+            % * __retval__ bool, return value
+            %
+            % If the previous call to constructor or open() succeeded, the method returns true.
+            %
+            % See also cv.VideoCapture.open
+            %
+            flag = VideoCapture_(this.id, 'isOpened');
+        end
+
+        function release(this)
+            %RELEASE  Closes video file or capturing device.
+            %
+            % The methods are automatically called by subsequent open() and by destructor.
+            %
+            % See also cv.VideoCapture.open
+            %
+            VideoCapture_(this.id, 'release');
+        end
+
+        function successFlag = grab(this)
+            %GRAB  Grabs the next frame from video file or capturing device.
+            %
+            % ## Output
+            % * __successFlag__ bool, success flag
+            %
+            % The function grabs the next frame from video file or camera and returns
+            % true (non-zero) in the case of success.
+            %
+            % The primary use of the function is in multi-camera environments, especially
+            % when the cameras do not have hardware synchronization. That is, you call
+            % grab() for each camera and after that call the slower method retrieve() to
+            % decode and get frame from each camera. This way the overhead on demosaicing
+            % or motion jpeg decompression etc. is eliminated and the retrieved frames
+            % from different cameras will be closer in time.
+            %
+            % See also cv.VideoCapture.read cv.VideoCapture.retrieve
+            %
+            successFlag = VideoCapture_(this.id, 'grab');
+        end
+
+        function frame = retrieve(this)
+            %RETRIEVE  Decodes and returns the grabbed video frame.
+            %
+            % The function decodes and returns the just grabbed frame. If no frames has
+            % been grabbed (camera has been disconnected, or there are no more frames
+            % in video file), the function returns an empty matrix.
+            %
+            % See also cv.VideoCapture.read cv.VideoCapture.grab
+            %
+            frame = VideoCapture_(this.id, 'retrieve');
+        end
+    end
+
 end

--- a/+cv/VideoWriter.m
+++ b/+cv/VideoWriter.m
@@ -80,5 +80,38 @@ classdef VideoWriter < handle
             VideoWriter_(this.id, 'write', frame);
         end
     end
-    
+
+    methods (Hidden = true)
+        function retval = open(this, filename, siz, varargin)
+            %OPEN  Initializes or reinitializes video writer.
+            %
+            % ## Input
+            % * __filename__ Name of the video file
+            % * __siz__ Size of the video frame in [width, height] format
+            %
+            % ## Output
+            % * __retval__ bool, indicates if video is successfully initialized
+            %
+            % The method opens video writer. Parameters are the same as
+            % in the constructor.
+            %
+            % See also cv.VideoWriter cv.VideoWriter.isOpened
+            %
+            retval = VideoWriter_(this.id, 'open', filename, siz, varargin{:});
+        end
+
+        function retval = isOpened(this)
+            %ISOPENED  Returns true if video writer has been successfully initialized.
+            %
+            % ## Output
+            % * __val__ bool, return value
+            %
+            % Returns true if video writer has been successfully initialized.
+            %
+            % See also cv.VideoWriter cv.VideoWriter.open
+            %
+            retval = VideoWriter_(this.id, 'isOpened');
+        end
+    end
+
 end


### PR DESCRIPTION
The following MEX functions:

```
src\+cv\private\VideoCapture_.cpp
src\+cv\private\VideoWriter_.cpp
```

have options that are not exposed in the MATLAB class wrappers. Although they are less frequently used.

I have included them in a "Hidden" methods block (wont show up in autocomplete)
