### PR TITLE
Added a keypoints output to DescriptorExtractor

### DIFF
--- a/+cv/DescriptorExtractor.m
+++ b/+cv/DescriptorExtractor.m
@@ -92,7 +92,7 @@ classdef DescriptorExtractor < handle
             t = DescriptorExtractor_(this.id, 'type');
         end
         
-        function descriptors = compute(this, im, keypoints)
+        function [descriptors, keypoints] = compute(this, im, keypoints)
             %COMPUTE  Computes the descriptors for a set of keypoints detected in an image
             %
             %    descroptors = extractor.compute(im, keypoints)
@@ -107,10 +107,11 @@ classdef DescriptorExtractor < handle
             %
             % ## Output
             % * __descriptors__ Computed descriptors.
+            % * __keypoints__ Keypoints for which descriptors have been computed.
             %
             % See also cv.DescriptorExtractor
             %
-            descriptors = DescriptorExtractor_(this.id, 'compute', im, keypoints);
+            [descriptors, keypoints] = DescriptorExtractor_(this.id, 'compute', im, keypoints);
         end
         
         function read(this, filename)

--- a/src/+cv/private/DescriptorExtractor_.cpp
+++ b/src/+cv/private/DescriptorExtractor_.cpp
@@ -26,7 +26,7 @@ map<int,Ptr<DescriptorExtractor> > obj_;
 void mexFunction( int nlhs, mxArray *plhs[],
                   int nrhs, const mxArray *prhs[] )
 {
-    if (nrhs<1 || nlhs>1)
+    if (nrhs<1 || nlhs>2)
         mexErrMsgIdAndTxt("mexopencv:error","Wrong number of arguments");
 
     if (last_id==0)
@@ -58,12 +58,12 @@ void mexFunction( int nlhs, mxArray *plhs[],
         obj_.erase(id);
     }
     else if (method == "size") {
-        if (nrhs!=2)
+        if (nrhs!=2 || nlhs!=1)
             mexErrMsgIdAndTxt("mexopencv:error","Wrong number of arguments");
         plhs[0] = MxArray(obj->descriptorSize());
     }
     else if (method == "type") {
-        if (nrhs!=2)
+        if (nrhs!=2 || nlhs!=1)
             mexErrMsgIdAndTxt("mexopencv:error","Wrong number of arguments");
         plhs[0] = MxArray(obj->descriptorType());
     }
@@ -74,6 +74,8 @@ void mexFunction( int nlhs, mxArray *plhs[],
         vector<KeyPoint> keypoints(rhs[3].toVector<KeyPoint>());
         obj->compute(image, keypoints, descriptors);
         plhs[0] = MxArray(descriptors);
+        if (nlhs>1)
+            plhs[1] = MxArray(keypoints);
     }
     else if (method == "read") {
         if (nrhs!=3 || nlhs!=0)


### PR DESCRIPTION
When an extractor cannot compute the descriptor, it removes the keypoint from the list. With this patch one can optionally get the updated list.
