### PR TITLE
Prevent calcOpticalFlowPyrLK from crashing on empty input

### DIFF
--- a/src/+cv/calcOpticalFlowPyrLK.cpp
+++ b/src/+cv/calcOpticalFlowPyrLK.cpp
@@ -56,8 +56,12 @@ void mexFunction( int nlhs, mxArray *plhs[],
     // Process
     vector<uchar> status(prevPts.size());
     vector<float> err(prevPts.size());
-    calcOpticalFlowPyrLK(prevImg, nextImg, prevPts, nextPts, status, err,
+
+    if (prevPts.size()>0) {
+        calcOpticalFlowPyrLK(prevImg, nextImg, prevPts, nextPts, status, err,
         winSize, maxLevel, criteria, flags, minEigThreshold);
+    }
+
     plhs[0] = MxArray(nextPts);
     if (nlhs>1)
         plhs[1] = MxArray(Mat(status));


### PR DESCRIPTION
Currently, a call to calcOpticalFlowPyrLK() with prevpts = [] leads to an assertion failure in OpenCV, which terminates MATLAB. To me the preferable solution is not to call cv::calcOpticalFlowPyrLK() and to return an empty result.
