### PR TITLE
Update MxArray.hpp

### DIFF
--- a/include/MxArray.hpp
+++ b/include/MxArray.hpp
@@ -199,6 +199,13 @@ class MxArray
     template <typename T> explicit MxArray(const std::vector<T>& v) {
         fromVector<T>(v);
     }
+    
+    /** MxArray test constructor from cv::Vec<T,N>
+     * @param v cv::Vec<T,N>
+     * @return N-element numeric MxArray.
+     */
+    template <typename T,int N> explicit MxArray(const cv::Vec<T,N>& v);
+    
     /** MxArray constructor from cv::Point_<T>.
      * @param p cv::Point_<T> object.
      * @return two-element numeric MxArray.
@@ -712,6 +719,17 @@ void MxArray::fromVector(const std::vector<T>& v)
         std::copy(v.begin(), v.end(), reinterpret_cast<T*>(mxGetData(p_)));
     }
 }
+
+template <typename T,int N> 
+MxArray::MxArray(const cv::Vec<T,N>& v):p_(mxCreateNumericMatrix(1, N, mxDOUBLE_CLASS,mxREAL))
+{
+    if (!p_)
+        mexErrMsgIdAndTxt("mexopencv:error", "Allocation error");
+    double *x = mxGetPr(p_);
+    for (int i =0;i<N;i++)
+        x[i]=v[i];
+
+} 
 
 template <typename T>
 MxArray::MxArray(const cv::Point_<T>& p) :


### PR DESCRIPTION
added contructor MxArray(const cv::Vec<T,N>& v)
can be used like this:
´´´
cv::vector<cv::Vec<double,2> > outarray(2);
outarray[0][0] =22;
outarray[0][1] =23;
outarray[1][0] =24;
outarray[1][1] =25;
// Convert cv::Mat to mxArray
plhs[0] = MxArray(outarray);
´´´