### PR TITLE
fix CV_LDFLAGS for Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LIB_SUFFIX  := %.so %.dylib %.a %.la %.dll.a %.dll
 CV_LDFLAGS  := $(shell pkg-config --libs opencv)
 CV_LDFLAGS  := $(filter-out $(LIB_SUFFIX),$(CV_LDFLAGS)) \
                $(addprefix -L, $(sort $(dir $(filter $(LIB_SUFFIX),$(CV_LDFLAGS))))) \
-               $(patsubst libopencv_%, -lopencv_%, \
+               $(patsubst lib%, -l%, \
                $(basename $(notdir $(filter $(LIB_SUFFIX),$(CV_LDFLAGS)))))
 LD_FLAGS    += $(CV_LDFLAGS)
 


### PR DESCRIPTION
perform pattern substitution on all shared libraries