### PR TITLE
Rewrite Makefile for OpenCV 3.0 compilation

### DIFF
--- a/+mexopencv/make.m
+++ b/+mexopencv/make.m
@@ -195,13 +195,20 @@ else % Unix
     options = {};
     if opts.dryrun         , options = [options '--dry-run']; end
     if opts.force          , options = [options '--always-make']; end
-    if opts.clean          , options = [options 'clean']; end
-    if opts.test           , options = [options 'test']; end
+    if opts.verbose < 1    , options = [options '--silent']; end
+    if opts.verbose > 1    , options = [options 'CFLAGS+=-v']; end
+    if opts.debug          , options = [options 'CFLAGS+=-g']; end
     if ~isempty(opts.extra), options = [options opts.extra]; end
 
+    targets = {'all'};
+    if opts.clean          , targets = ['clean' targets]; end
+    if opts.opencv_contrib , targets = [targets 'contrib']; end
+    if opts.test           , targets = [targets 'test']; end
+
     % call Makefile
-    cmd = sprintf('make MATLABDIR="%s" MEXEXT=%s %s', ...
-        matlabroot, mexext, sprintf(' %s', options{:}));
+    cmd = sprintf('make MATLABDIR="%s" MEXEXT=%s %s %s', ...
+        matlabroot, mexext, ...
+        sprintf(' %s', options{:}), sprintf(' %s', targets{:}));
     if opts.verbose > 0, disp(cmd); end
     system(cmd);
 end

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,135 @@
-MATLABDIR   ?= /usr/local/matlab
-MEX         ?= $(MATLABDIR)/bin/mex
-MATLAB      ?= $(MATLABDIR)/bin/matlab
-MEXEXT      ?= $(shell $(MATLABDIR)/bin/mexext)
-DOXYGEN     ?= doxygen
-TARGETDIR   := +cv
-INCLUDEDIR  := include
-LIBDIR      := lib
-SRCDIR	    := src
-MEXDIR	    := $(SRCDIR)/$(TARGETDIR)
-SRCS        := $(wildcard $(MEXDIR)/*.cpp) $(wildcard $(MEXDIR)/private/*.cpp)
-TARGETS     := $(subst $(MEXDIR), $(TARGETDIR), $(SRCS:.cpp=.$(MEXEXT)))
-C_FLAGS     := -cxx -largeArrayDims -I$(INCLUDEDIR) $(shell pkg-config --cflags opencv)
-LD_FLAGS    := -L$(LIBDIR)
+#!/usr/bin/make -f
 
-# append OpenCV linking flags
-LIB_SUFFIX  := %.so %.dylib %.a %.la %.dll.a %.dll
-CV_LDFLAGS  := $(shell pkg-config --libs opencv)
-CV_LDFLAGS  := $(filter-out $(LIB_SUFFIX),$(CV_LDFLAGS)) \
-               $(addprefix -L, $(sort $(dir $(filter $(LIB_SUFFIX),$(CV_LDFLAGS))))) \
-               $(patsubst lib%, -l%, \
-               $(basename $(notdir $(filter $(LIB_SUFFIX),$(CV_LDFLAGS)))))
-LD_FLAGS    += $(CV_LDFLAGS)
+# ============================================================================
+#                              mexopencv Makefile
+# ============================================================================
+#
+# The following configuration parameters are recognized:
+#
+# MATLABDIR             MATLAB root directory.
+# MATLAB                MATLAB executable.
+# MEX                   MATLAB MEX compiler frontend.
+# MEXEXT                extension of MEX-files.
+# DOXYGEN               Doxygen executable used to generate documentation.
+# NO_CV_PKGCONFIG_HACK  Boolean. If not set, we attempt to fix the output of
+#                       pkg-config for OpenCV.
+# CFLAGS                Extra flags to give to the C/C++ MEX compiler.
+# LDFLAGS               Extra flags to give to compiler when it invokes the
+#                       linker.
+#
+# The above settings can be defined as shell environment variables and/or
+# specified on the command line as arguments to make:
+#
+#    export VAR=value
+#    make VAR=value
+#
+# The following targets are available:
+#
+# all      Builds mexopencv.
+# contrib  Builds the extra modules. Needs opencv_contrib.
+# clean    Deletes temporary and generated files.
+# doc      Generates source documentation using Doxygen.
+# test     Run MATLAB unit-tests.
+#
+# Note that the Makefile uses pkg-config to locate OpenCV, so you need to have
+# the opencv.pc file accessible from the PKG_CONFIG_PATH environment variable.
+#
+# Required OpenCV version: 3.0
+#
+# ============================================================================
 
-VPATH       = $(TARGETDIR):$(SRCDIR):$(MEXDIR):$(TARGETDIR)/private:$(SRCDIR)/private
+# programs
+MATLABDIR  ?= /usr/local/matlab
+MEX        ?= $(MATLABDIR)/bin/mex
+MATLAB     ?= $(MATLABDIR)/bin/matlab
+DOXYGEN    ?= doxygen
 
-.PHONY : all clean doc test
+# mexopencv directories
+TARGETDIR  = +cv
+INCLUDEDIR = include
+LIBDIR     = lib
+SRCDIR     = src
+PRIVATEDIR = private
+CONTRIBDIR = opencv_contrib
 
-all: $(TARGETS)
+# file extensions
+OBJEXT     ?= o
+LIBEXT     ?= a
+MEXEXT     ?= $(shell $(MATLABDIR)/bin/mexext)
+ifeq ($(MEXEXT),)
+    $(error "MEX extension not set")
+endif
 
-$(LIBDIR)/libMxArray.a: $(SRCDIR)/MxArray.cpp $(INCLUDEDIR)/MxArray.hpp
-	$(MEX) -c $(C_FLAGS) $< -outdir $(LIBDIR)
-	$(AR) -cq $@ $(LIBDIR)/*.o
-	$(RM) $(LIBDIR)/*.o
+# mexopencv files and targets
+HEADERS    := $(wildcard $(INCLUDEDIR)/*.hpp)
+SRCS0      := $(wildcard $(SRCDIR)/*.cpp)
+SRCS1      := $(wildcard $(SRCDIR)/$(TARGETDIR)/*.cpp) \
+              $(wildcard $(SRCDIR)/$(TARGETDIR)/$(PRIVATEDIR)/*.cpp)
+SRCS2      := $(wildcard $(CONTRIBDIR)/$(SRCDIR)/$(TARGETDIR)/*.cpp) \
+              $(wildcard $(CONTRIBDIR)/$(SRCDIR)/$(TARGETDIR)/$(PRIVATEDIR)/*.cpp)
+OBJECTS0   := $(subst $(SRCDIR), $(LIBDIR), $(SRCS0:.cpp=.$(OBJEXT)))
+TARGETS0   := $(LIBDIR)/libMxArray.$(LIBEXT)
+TARGETS1   := $(subst $(SRCDIR)/$(TARGETDIR), $(TARGETDIR), $(SRCS1:.cpp=.$(MEXEXT)))
+TARGETS2   := $(subst $(CONTRIBDIR)/$(SRCDIR)/$(TARGETDIR), $(CONTRIBDIR)/$(TARGETDIR), $(SRCS2:.cpp=.$(MEXEXT)))
 
-%.$(MEXEXT): %.cpp $(LIBDIR)/libMxArray.a $(INCLUDEDIR)/mexopencv.hpp
-	$(MEX) $(C_FLAGS) $< -lMxArray $(LD_FLAGS) -output ${@:.$(MEXEXT)=}
+# OpenCV flags
+ifneq ($(shell pkg-config --exists --atleast-version=3 opencv; echo $$?), 0)
+    $(error "OpenCV 3.0 package was not found in the pkg-config search path")
+endif
+CV_CFLAGS  := $(shell pkg-config --cflags opencv)
+CV_LDFLAGS := $(shell pkg-config --libs opencv)
+ifndef NO_CV_PKGCONFIG_HACK
+LIB_SUFFIX := %.so %.dylib %.a %.la %.dll.a %.dll
+CV_LDFLAGS := $(filter-out $(LIB_SUFFIX),$(CV_LDFLAGS)) \
+              $(addprefix -L, \
+                  $(sort $(dir $(filter $(LIB_SUFFIX),$(CV_LDFLAGS))))) \
+              $(patsubst lib%, -l%, \
+                  $(basename $(notdir $(filter $(LIB_SUFFIX),$(CV_LDFLAGS)))))
+endif
+
+# compiler/linker flags
+override CFLAGS  += -cxx -largeArrayDims -I$(INCLUDEDIR) $(CV_CFLAGS)
+override LDFLAGS += -L$(LIBDIR) -lMxArray $(CV_LDFLAGS)
+
+# search path for prerequisites of pattern rules
+# Note that VPATH/vpath are designed to find sources, not targets!
+# (http://make.mad-scientist.net/papers/how-not-to-use-vpath/)
+vpath %.cpp $(SRCDIR)/$(TARGETDIR)
+vpath %.cpp $(SRCDIR)/$(TARGETDIR)/$(PRIVATEDIR)
+vpath %.cpp $(CONTRIBDIR)/$(SRCDIR)/$(TARGETDIR)
+vpath %.cpp $(CONTRIBDIR)/$(SRCDIR)/$(TARGETDIR)/$(PRIVATEDIR)
+
+# special targets
+.PHONY : all contrib clean doc test
+.SUFFIXES: .cpp .$(OBJEXT) .$(LIBEXT) .$(MEXEXT)
+
+# targets
+all: $(TARGETS1)
+contrib:  $(TARGETS2)
+
+# MxArray objects
+$(LIBDIR)/%.$(OBJEXT): $(SRCDIR)/%.cpp $(HEADERS)
+	$(MEX) -c $(CFLAGS) -outdir $(LIBDIR) $<
+
+# MxArray library
+$(TARGETS0): $(OBJECTS0)
+	$(AR) -cq $@ $^
+
+# MEX-files
+$(TARGETDIR)/%.$(MEXEXT) \
+$(TARGETDIR)/$(PRIVATEDIR)/%.$(MEXEXT) \
+$(CONTRIBDIR)/$(TARGETDIR)/%.$(MEXEXT) \
+$(CONTRIBDIR)/$(TARGETDIR)/$(PRIVATEDIR)/%.$(MEXEXT) \
+: %.cpp $(TARGETS0)
+	$(MEX) $(CFLAGS) -output ${@:.$(MEXEXT)=} $< $(LDFLAGS)
 
 clean:
-	$(RM) -r $(LIBDIR)/*.a $(TARGETDIR)/*.$(MEXEXT) $(TARGETDIR)/private/*.$(MEXEXT)
+	$(RM) -r \
+        $(LIBDIR)/*.$(LIBEXT) $(LIBDIR)/*.$(OBJEXT) \
+        $(TARGETDIR)/*.$(MEXEXT) \
+        $(TARGETDIR)/$(PRIVATEDIR)/*.$(MEXEXT) \
+        $(CONTRIBDIR)/$(TARGETDIR)/*.$(MEXEXT) \
+        $(CONTRIBDIR)/$(TARGETDIR)/$(PRIVATEDIR)/*.$(MEXEXT)
 
 doc:
 	$(DOXYGEN) Doxyfile


### PR DESCRIPTION
Update makefile following the move to OpenCV 3.0:

- handle the `mexopencv_features2d.cpp` file
- add a new make target `contrib` to compiles MEX-files under the `opencv_contrib` directory
- fix the use of VPATH/vpath which are [designed](http://make.mad-scientist.net/papers/how-not-to-use-vpath/) for finding sources not targets
- test `opencv` package using `pkg-config` and die otherwise (no need to continue)
- add an optional variable `NO_CV_PKGCONFIG_HACK` which when set disables the hacks we used to do to fix the output of `pkg-config --libs opencv`. From what I can tell, the generated `opencv.pc` has finally been fixed in OpenCV :relieved: but I'm not sure..
- add some help comments
- various other edits

This has not been thoroughly tested, so I appreciate if you could try it in Linux or OSX on your end :)

---

*In fact, and for power users, the Makefile should now be flexible enough that it could even compile on Windows using `make` under [Cygwin](https://cygwin.com/) (it'll still need a few tweaks here and there to make it happy like using `LIB.exe` instead of `AR` to build the static library)...*
