### PR TITLE
Fix the build issues on OS X 10.11 / Homebrew / Octave 4.0 / OpenCV 3.0 environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 # DOXYGEN               Doxygen executable used to generate documentation.
 # NO_CV_PKGCONFIG_HACK  Boolean. If not set, we attempt to fix the output of
 #                       pkg-config for OpenCV.
+# PKG_CONFIG_OPENCV     Name of the OpenCV 3.0 package in pkg-config. By
+#                       default, opencv.
 # CFLAGS                Extra flags to give to the C/C++ MEX compiler.
 # LDFLAGS               Extra flags to give to compiler when it invokes the
 #                       linker.
@@ -88,11 +90,12 @@ TARGETS1   := $(subst $(SRCDIR)/$(TARGETDIR), $(TARGETDIR), $(SRCS1:.cpp=.$(MEXE
 TARGETS2   := $(subst $(CONTRIBDIR)/$(SRCDIR)/$(TARGETDIR), $(CONTRIBDIR)/$(TARGETDIR), $(SRCS2:.cpp=.$(MEXEXT)))
 
 # OpenCV flags
-ifneq ($(shell pkg-config --exists --atleast-version=3 opencv; echo $$?), 0)
+PKG_CONFIG_OPENCV ?= opencv
+ifneq ($(shell pkg-config --exists --atleast-version=3 $(PKG_CONFIG_OPENCV); echo $$?), 0)
     $(error "OpenCV 3.0 package was not found in the pkg-config search path")
 endif
-CV_CFLAGS  := $(shell pkg-config --cflags opencv)
-CV_LDFLAGS := $(shell pkg-config --libs opencv)
+CV_CFLAGS  := $(shell pkg-config --cflags $(PKG_CONFIG_OPENCV))
+CV_LDFLAGS := $(shell pkg-config --libs $(PKG_CONFIG_OPENCV))
 ifndef NO_CV_PKGCONFIG_HACK
 LIB_SUFFIX := %.so %.dylib %.a %.la %.dll.a %.dll
 CV_LDFLAGS := $(filter-out $(LIB_SUFFIX),$(CV_LDFLAGS)) \

--- a/src/MxArray.cpp
+++ b/src/MxArray.cpp
@@ -733,13 +733,14 @@ mwIndex MxArray::subs(mwIndex i, mwIndex j) const
 {
     if (i >= rows() || j >= cols())
         mexErrMsgIdAndTxt("mexopencv:error", "Subscript out of range");
-    const mwIndex si[] = {i, j};
+    mwIndex si[] = {i, j};
     return mxCalcSingleSubscript(p_, 2, si);
 }
 
 mwIndex MxArray::subs(const std::vector<mwIndex>& si) const
 {
-    return mxCalcSingleSubscript(p_, si.size(), (!si.empty() ? &si[0] : NULL));
+    std::vector<mwIndex> v(si);
+    return mxCalcSingleSubscript(p_, si.size(), (!v.empty() ? &v[0] : NULL));
 }
 
 MxArray MxArray::at(const std::string& fieldName, mwIndex index) const


### PR DESCRIPTION
To build on OS X / Homebrew / Octave / OpenCV 3.0,

    brew install homebrew/science/opencv3
    brew install homebrew/science/octave --build-from-source
    make PKG_CONFIG_OPENCV=opencv3 WITH_OCTAVE=1

Octave binary package in Homebrew is broken, and probably needs to be built from source. There are still tons of errors in test...