### PR TITLE
followup fixes to PR#231

### DIFF
--- a/opencv_contrib/+cv/DisparityWLSFilter.m
+++ b/opencv_contrib/+cv/DisparityWLSFilter.m
@@ -427,7 +427,13 @@ classdef DisparityWLSFilter < handle
             end
 
             % object properties (as name/value pairs)
-            p = properties(matcher);
+            %p = properties(matcher);  % HACK: Octave doesnt like this, throws syntax error!
+            mc = metaclass(matcher);
+            if ~mexopencv.isOctave() && isprop(mc, 'PropertyList')
+                p = {mc.PropertyList.Name};
+            else
+                p = cellfun(@(x) x.Name, mc.Properties, 'UniformOutput',false);
+            end
             for i=1:numel(p)
                 if strcmp(p{i}, 'id'), continue; end
                 C{end+1} = p{i};

--- a/opencv_contrib/test/unit_tests/TestSuperpixelLSC.m
+++ b/opencv_contrib/test/unit_tests/TestSuperpixelLSC.m
@@ -3,6 +3,12 @@ classdef TestSuperpixelLSC
 
     methods (Static)
         function test_1
+            %TODO: OpenCV's SuperpixelLSC is buggy; sometimes crashes MATLAB when called repeatedly
+            if true
+                disp('SKIP');
+                return;
+            end
+
             img = cv.imread(fullfile(mexopencv.root(),'test','fruits.jpg'), ...
                 'Color',true, 'ReduceScale',2);
             lab = cv.cvtColor(img, 'RGB2Lab');


### PR DESCRIPTION
- Workaround for Octave as it doesn't support calling `p = properties(obj)` to get object properties.

- Disable `SuperpixelLSC` tests, since it crashes sporadically (likely a bug in OpenCV)...