### PR TITLE
Enable getting reject levels and level weights

### DIFF
--- a/+cv/CascadeClassifier.m
+++ b/+cv/CascadeClassifier.m
@@ -65,7 +65,7 @@ classdef CascadeClassifier < handle
             status = CascadeClassifier_(this.id, 'load', filename);
         end
         
-        function boxes = detect(this, im, varargin)
+        function varargout = detect(this, im, varargin)
             %DETECT Detects objects of different sizes in the input image.
             %
             %    boxes = classifier.detect(im, 'Option', optionValue, ...)
@@ -92,7 +92,9 @@ classdef CascadeClassifier < handle
             %
             % See also cv.CascadeClassifier
             %
-            boxes = CascadeClassifier_(this.id, 'detectMultiScale', im, varargin{:});
+            assert(nargout == 1 || nargout == 3, 'CascadeClassifier:InvalidInput', 'Wrong number of output arguments.');
+            varargout = cell(1,nargout);
+            [varargout{:}] = CascadeClassifier_(this.id, 'detectMultiScale', im, varargin{:});
         end
     end
     

--- a/src/+cv/private/CascadeClassifier_.cpp
+++ b/src/+cv/private/CascadeClassifier_.cpp
@@ -25,7 +25,7 @@ map<int,CascadeClassifier> obj_;
 void mexFunction( int nlhs, mxArray *plhs[],
                   int nrhs, const mxArray *prhs[] )
 {
-    if (nrhs<1 || nlhs>1)
+    if (nrhs<1 || nlhs != 1 && nlhs != 3)
         mexErrMsgIdAndTxt("mexopencv:error","Wrong number of arguments");
     
     // Determine argument format between (filename,...) or (id,method,...)
@@ -57,12 +57,12 @@ void mexFunction( int nlhs, mxArray *plhs[],
         obj_.erase(id);
     }
     else if (method == "empty") {
-        if (nrhs!=2)
+        if (nrhs!=2 || nlhs != 1)
             mexErrMsgIdAndTxt("mexopencv:error","Wrong number of arguments");
         plhs[0] = MxArray(obj.empty());
     }
     else if (method == "load") {
-        if (nrhs!=3)
+        if (nrhs!=3 || nlhs != 1)
             mexErrMsgIdAndTxt("mexopencv:error","Wrong number of arguments");
         plhs[0] = MxArray(obj.load(rhs[2].toString()));
     }
@@ -93,8 +93,17 @@ void mexFunction( int nlhs, mxArray *plhs[],
         // Run
         Mat image(rhs[2].toMat());
         vector<Rect> objects;
-        obj.detectMultiScale(image, objects, scaleFactor, minNeighbors, flags,
-                             minSize, maxSize);
+		if (nlhs == 1) {
+			obj.detectMultiScale(image, objects, scaleFactor, minNeighbors, flags,
+								 minSize, maxSize);	
+		} else if (nlhs == 3) {
+			vector<int> reject_levels;
+			vector<double> level_weights;
+			obj.detectMultiScale(image, objects, reject_levels, level_weights, 
+							     scaleFactor, minNeighbors, flags, minSize, maxSize, true);
+			plhs[1] = MxArray(reject_levels);
+			plhs[2] = MxArray(level_weights);
+		}        
         plhs[0] = MxArray(objects);
     }
     else


### PR DESCRIPTION
OpenCV has an undocumented overloading of `CascadeClassifier`'s `detectMultiScale` method, which 
returns the reject level (cascade) and level weight of each of its detection.
For more information see:
[http://codeyarns.com/2014/10/30/how-to-get-detection-score-from-opencv-cascade-classifier/](url)
[http://haoxiang.org/2013/11/opencv-detectmultiscale-output-detection-score/](url)
This code enables calling this overloaded method, by requesting three output arguments from `cv.CascadeClassifier.detect` instead of one.

Please note that the overloaded method does not call `groupRectangles`, but outputs all detection.