### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/test/unit_tests/TestHOGDescriptor.m
+++ b/test/unit_tests/TestHOGDescriptor.m
@@ -194,7 +194,7 @@ function fname = get_pedestrian_video()
     fname = fullfile(mexopencv.root(),'test','768x576.avi');
     if exist(fname, 'file') ~= 2
         % download video from Github
-        url = 'https://cdn.rawgit.com/opencv/opencv/3.1.0/samples/data/768x576.avi';
+        url = 'https://cdn.combinatronics.com/opencv/opencv/3.1.0/samples/data/768x576.avi';
         urlwrite(url, fname);
     end
 end


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.